### PR TITLE
Add optional language tag support for code blocks

### DIFF
--- a/content/gotraining.slide
+++ b/content/gotraining.slide
@@ -551,6 +551,7 @@ TODO
 For non-trivial size projects follow the layout suggested by [[https://github.com/golang-standards/project-layout][golang-standards]]
 Abridged and ANZ adjusted version:
 
+	language:none
 	├── README.md
 	├── go.mod
 	├── go.sum
@@ -574,6 +575,7 @@ Abridged and ANZ adjusted version:
 
 * Go tool chain
 
+	language:bash
 	go help
 	go version
 	go build ./...

--- a/templates/slides.tmpl
+++ b/templates/slides.tmpl
@@ -105,8 +105,25 @@
         languages: ['bash', 'markdown', 'go', 'java']
       })
 
+      var reLanguageTag = /^\s*language:(\w+)\n?([\s\S]*)/m
+
       document.querySelectorAll('.code pre').forEach( el => {
-        hljs.highlightBlock(el)
+        var textContent = el.innerText
+        var languageTag = reLanguageTag.exec(textContent)
+
+        if (languageTag) {
+          var newTextContent = languageTag[2]
+          languageTag = languageTag[1]
+
+          el.classList.add(languageTag)
+          el.innerText = newTextContent.trim()
+
+          if (languageTag !== 'none') {
+            hljs.highlightBlock(el)
+          }
+        } else {
+          hljs.highlightBlock(el)
+        }
       })
     </script>
   </body>

--- a/templates/slides.tmpl
+++ b/templates/slides.tmpl
@@ -109,19 +109,19 @@
 
       document.querySelectorAll('.code pre').forEach( el => {
         var textContent = el.innerText
-        var languageTag = reLanguageTag.exec(textContent)
+        var match = reLanguageTag.exec(textContent)
+        var languageTag
+     
+        if (!match) {
+          hljs.highlightBlock(el)
 
-        if (languageTag) {
-          var newTextContent = languageTag[2]
-          languageTag = languageTag[1]
+          return
+        }
 
-          el.classList.add(languageTag)
-          el.innerText = newTextContent.trim()
-
-          if (languageTag !== 'none') {
-            hljs.highlightBlock(el)
-          }
-        } else {
+        languageTag = match[1]
+        el.innerText = match[2].trim()
+        el.classList.add(languageTag)
+        if (languageTag !== 'none') {
           hljs.highlightBlock(el)
         }
       })


### PR DESCRIPTION
- implemented in the JS bootstrapping phase of hightlightjs
  - it simply checks if the first line of the text is of the form `language:foo` (where `foo` is the language, or `none`)
- this uses an undocumented feature of highlightjs where it will respect CSS classes on an element if they match a known language

Your slide's code blocks will behave as normal if left as-is.

Disabling syntax checking:
```
  language:none
  your
  text
  here
```

Overriding syntax autodetection:
```
  language:java
  this isn't really java
```