### PR TITLE
Move "Motivation" to "Overview" section

### DIFF
--- a/content/gocourse-2019-05-melbourne.slide
+++ b/content/gocourse-2019-05-melbourne.slide
@@ -135,9 +135,6 @@ Go favours simplicity and directness resulting in some purposeful omissions:
 - No arguments about code style :)
 
 
-* Motivation and Demo
-
-
 * Why Go
 
 - simple: easy to learn and read
@@ -148,6 +145,9 @@ Go favours simplicity and directness resulting in some purposeful omissions:
 - lightweight concurrency
 
 Here is a great read on Rob Pike's blog about "Why Go" - ([[https://commandcenter.blogspot.com/2012/06/less-is-exponentially-more.html][Less is Exponentially More]])
+
+
+* Demo
 
 
 * Demo


### PR DESCRIPTION
Move the Motivation section ("Why Go?") from the "Motivation & Demo"
section into the "History and Overview" section. It fits better there
thematically, and also provides a good point to switch presenters to
present the demo.

Closes #72

Deployed at http://pr73-dot-gotraining-testing.appspot.com/