### PR TITLE
Create a slide to list Go Concurrency topics and Concurrency in Go Slide

### DIFF
--- a/content/gocourse-2019-05-melbourne.slide
+++ b/content/gocourse-2019-05-melbourne.slide
@@ -937,7 +937,8 @@ Definition
 
 * Concurrency in Go
 
-- Go provides:
+Go provides:
+
 - Concurrent execution (goroutines)
 - Synchronisation and message passing (channels)
 - Multi-way concurrent control (select)

--- a/content/gocourse-2019-05-melbourne.slide
+++ b/content/gocourse-2019-05-melbourne.slide
@@ -914,21 +914,33 @@ Embedding types introduces the possiblity for naming conflicts. Go follows some 
 
 * Topics
 
+- Concurrency
 - Concurrency in Go
-- Processes, threads and goroutines
-- Go Scheduler
 - Goroutines
-- Wait Group
 - Channels
-- Mutex
-- Select
+- Range & Select
+- Under the hood: Processes, Threads, Goroutines
+- Under the hood: Go Runtime
 
-* Concurrency in Go
+* Concurrency
+
+Definition
+
+- Concurrency is the ability of different parts or units of a program, algorithm, or problem to be executed out-of-order or in partial order, without affecting the final outcome ([[https://en.wikipedia.org/wiki/Concurrent_computing][Source: Wikipedia]])
+- Parallelism is the ability to run different parts or units of a program simultaneously
+
+[[https://go-proverbs.github.io/][Rob Pike]] ([[https://www.youtube.com/watch?v=cN_DpYBzKso][Talk]], [[https://talks.golang.org/2012/waza.slide][Slides]])
 
 - "Don't communicate by sharing memory, share memory by communicating."
 - "Concurrency is not parallelism."
 - "Concurrency is about structure, parallelism is about execution."
-- [[https://go-proverbs.github.io/][Rob Pike]] ([[https://www.youtube.com/watch?v=cN_DpYBzKso][Talk]], [[https://talks.golang.org/2012/waza.slide][Slides]])
+
+* Concurrency in Go
+
+- Go provides:
+- Concurrent execution (goroutines)
+- Synchronisation and message passing (channels)
+- Multi-way concurrent control (select)
 
 * Channels
 

--- a/content/gocourse-2019-05-melbourne.slide
+++ b/content/gocourse-2019-05-melbourne.slide
@@ -914,6 +914,7 @@ Embedding types introduces the possiblity for naming conflicts. Go follows some 
 
 * Topics
 
+- Concurrency in Go
 - Processes, threads and goroutines
 - Go Scheduler
 - Goroutines
@@ -921,6 +922,13 @@ Embedding types introduces the possiblity for naming conflicts. Go follows some 
 - Channels
 - Mutex
 - Select
+
+* Concurrency in Go
+
+- "Don't communicate by sharing memory, share memory by communicating."
+- "Concurrency is not parallelism."
+- "Concurrency is about structure, parallelism is about execution."
+- [[https://go-proverbs.github.io/][Rob Pike]] ([[https://www.youtube.com/watch?v=cN_DpYBzKso][Talk]], [[https://talks.golang.org/2012/waza.slide][Slides]])
 
 * Channels
 

--- a/content/gocourse-2019-05-melbourne.slide
+++ b/content/gocourse-2019-05-melbourne.slide
@@ -910,6 +910,18 @@ Embedding types introduces the possiblity for naming conflicts. Go follows some 
 - Add locking for proper use of sync.Map
 - Bonus points: Add a third `Storer` implementation using [[https://github.com/syndtr/goleveldb][LevelDB]]
 
+* Go Concurrency
+
+* Topics
+
+- Processes, threads and goroutines
+- Go Scheduler
+- Goroutines
+- Wait Group
+- Channels
+- Mutex
+- Select
+
 * Channels
 
 - Communication mechanism (conduit) that lets goroutines exchange data


### PR DESCRIPTION
This PR has 3 slides

- Header
- Topics
- Concurrency in Go

**Topics**
Concurrency
Concurrency in Go
Goroutines
Channels
Range & Select
Under the hood: Processes, Threads, Goroutines
Under the hood: Go Runtime

https://pr82-dot-gotraining-testing.appspot.com/gocourse-2019-05-melbourne.slide#73