### PR TITLE
Remove @camh-anz quote markings

### DIFF
--- a/content/gocourse-2019-05-melbourne.slide
+++ b/content/gocourse-2019-05-melbourne.slide
@@ -454,7 +454,7 @@ Before adding any commits to `feature` locally run:
 
 * Pull Request (PR) recommendations (2/2)
 
-- "Think of the reviewer: your code needs to be reviewable and that should be a prime concern when writing your code, commits and PRs." (@camh-anz)
+- Think of the reviewer: your code needs to be reviewable and that should be a prime concern when writing your code, commits and PRs
 - Tag your PR Title with `[WIP]` if adjustments are needed
 - Rework fixup commits with `git` `rebase` `-i`  `COMMIT_HASH` and force push
 - Add reviewers and remove `[WIP]` tag when all of the above are met


### PR DESCRIPTION
Remove the quote characters and the @camh-anz attribution from the
"Think of the reviewer" quote. That is not (yet) a widely-spread message
that quoting it makes sense. And since I (camh-anz) will be presenting
that at the next course, quoting yourself feels a bit silly.

Changes can be viewed at https://pr92-dot-gotraining-testing.appspot.com/gocourse-2019-05-melbourne.slide#36

Closes: #92 