### PR TITLE
Add `godoc` to "Why Go" tools

### DIFF
--- a/content/gocourse-2019-05-melbourne.slide
+++ b/content/gocourse-2019-05-melbourne.slide
@@ -139,7 +139,7 @@ Go favours simplicity and directness resulting in some purposeful omissions:
 
 - simple: easy to learn and read
 - a single obvious right way to do most things
-- tools - `gofmt`, `goimports`, `go` `mod`, `go` `test`, `golangci-lint`, coverage
+- tools - `gofmt`, `goimports`, `godoc`, `go` `mod`, `go` `test`, `golangci-lint`, coverage
 - standard library
 - productive and fun
 - lightweight concurrency


### PR DESCRIPTION
godoc is pretty important in the land of Go tooling. Make sure it gets a
mention.

View at https://pr97-dot-gotraining-testing.appspot.com/gocourse-2019-05-melbourne.slide#13