### PR TITLE
Merge PR: redirect, add Keilin, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ This projects is continuously deployed to Appengine at [`https://gotraining.apps
 
 Run the present tool locally with
 
-    go build .
-    ./go-slides -base . -content content
+    go run . -base . -content content
 
+For an Appengine like environment run
+
+    GAE_ENV=standard go run .
 
 ## Appengine deployment
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ otherwise), you can disable SSL validation as a last resort:
 You will need to authenticate the new configuration:
 
     gcloud auth login
-    
+
 ### Deployment for PR review
 
 When you have a PR open for review, you can deploy the changes under
@@ -59,7 +59,7 @@ easily be cleaned up when your PR is closed.
 1. Review the changes as your reviewer will see them
 
 1. When done, delete the app engine service:
-     `gcloud --configuration=gotraining-testing app services delete prNN`
+   `gcloud --configuration=gotraining-testing app services delete prNN`
 
 1. Undo changes to `app.yaml`: `git checkout -- app.yaml`
 
@@ -67,8 +67,7 @@ Please make sure you do not commit a version of `app.yaml` with your
 `service:` line in it. This should only ever be local to your workspace.
 
 You should also make sure your workspace is clean of changes so what you
-deploy is what is on the PR branch in github. run `git describe --all
---dirty` and if that outputs a string with `-dirty` on the end, you have
+deploy is what is on the PR branch in github. run `git describe --all --dirty` and if that outputs a string with `-dirty` on the end, you have
 uncommitted changes. Stash them before you deploy (`git stash -u`) and
 unstash after (`git stash pop`). Note that you should check this before
 modifying the `app.yaml` file as that will make your workspace dirty.
@@ -77,7 +76,7 @@ only dirtyness is the `service: prNN` line in `app.yaml`.
 
 ### Manual production Appengine deployment
 
-Request access to GCP `gotraining` project from a [contributor](https://github.com/anz-bank/go-slides/graphs/contributors). 
+Request access to GCP `gotraining` project from a [contributor](https://github.com/anz-bank/go-slides/graphs/contributors).
 
 Add a new gcloud configuration as described in the [Appengine deployment](#appengine-deployment) section, using `gotraining` instead of `gotraining-testing`.
 

--- a/content/gocourse-2019-05-melbourne.slide
+++ b/content/gocourse-2019-05-melbourne.slide
@@ -5,6 +5,7 @@ Cameron Hutchison
 Daniel Cantos
 Joshua Carpeggiani
 Julia Ogris
+Keilin Olsen
 Ryan O'Kane
 Sai Kiran Gummaraj
 
@@ -63,10 +64,13 @@ The last 30 minutes of each talk are reserved for Q&A and help.
 Please join [[https://anzengineering.slack.com/messages/CFCPLHFT2/convo/CFCPLHFT2-1557100844.007600/][#go-course]] on [[https://anzengineering.slack.com]]
 
 *Instructors*
+go-instructors@anz.com
+
 [[https://anzengineering.slack.com/team/U5PTX8C1F][@camh]], Cameron.Hutchison@anz.com
 [[https://anzengineering.slack.com/team/UCUUKEWGZ][@Dan]], Daniel.Cantos@anz.com
 [[https://anzengineering.slack.com/team/UJC0EUZ3P][@joshcarp]], Joshua.Carpeggiani@anz.com
 [[https://anzengineering.slack.com/team/U84CTGB0F][@julia]], Julia.Ogris@anz.com
+[[https://anzengineering.slack.com/team/U8QFMQUJE][@keilin]], Keilin.Olsen@anz.com
 [[https://anzengineering.slack.com/team/U7M6DMFMY][@ryanokane]], Ryan.O'Kane@anz.com
 [[https://anzengineering.slack.com/team/UC9C4K2ES][@saikirian]], SaiKiran.Gummaraj@anz.com
 

--- a/dir.go
+++ b/dir.go
@@ -24,11 +24,17 @@ func init() {
 
 // dirHandler serves a directory listing for the requested path, rooted at *contentPath.
 func dirHandler(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path == "/favicon.ico" {
+	urlPath := strings.Trim(r.URL.Path, "/")
+	if urlPath == "favicon.ico" {
 		http.NotFound(w, r)
 		return
+	} else if urlPath == "" {
+		http.Redirect(w, r, "/gocourse-2019-05-melbourne.slide", 301)
+		return
+	} else if urlPath == "list" {
+		urlPath = "/"
 	}
-	name := filepath.Join(*contentPath, r.URL.Path)
+	name := filepath.Join(*contentPath, urlPath)
 	if isDoc(name) {
 		err := renderDoc(w, name)
 		if err != nil {


### PR DESCRIPTION
Various unrelated changed added in in one PR cause Sunday 10pm.

- Add a redirect so people can find "current" slides at https://go-course.org  
  (slide listing is still available under `/list`)
- Add Keilin as course instructor
- Update README.md with prettier formatting
- Add local execution instructions for Appengine like environment.
 
https://pr98-dot-gotraining-testing.appspot.com