### PR TITLE
Fix typo in lab3

### DIFF
--- a/content/gocourse-2019-05-melbourne.slide
+++ b/content/gocourse-2019-05-melbourne.slide
@@ -588,7 +588,7 @@ If `master` on upstream has advanced in the meantime:
 
 	func sortLetters(m map[rune]int) []string
 
-- Call `fmt.Println(strings.Join(sortLetters(letters("aba"))),` `"\n")` in `main` to print:
+- Call `fmt.Println(strings.Join(sortLetters(letters("aba")),` `"\n"))` in `main` to print:
 
 	a:2
 	b:1


### PR DESCRIPTION
Move parenthesis in lab3 main function so the function
compiles and executes correctly.

Deployment: https://pr102-dot-gotraining-testing.appspot.com/gocourse-2019-05-melbourne.slide#56